### PR TITLE
MAINT: Remove kustomize from install routine for now

### DIFF
--- a/Brewfile.example
+++ b/Brewfile.example
@@ -307,7 +307,6 @@ brew 'libyaml'
 ##
 brew 'git'
 brew 'graphviz'
-brew 'kustomize'
 brew 'libevent'
 brew 'libjpg'
 brew 'libmagic'


### PR DESCRIPTION
Remove kustomize from install routine for now, because it must be pinned to 3.8 for Friedbert, which must be done manually..